### PR TITLE
Custom verbs

### DIFF
--- a/lib/t.rb
+++ b/lib/t.rb
@@ -1,4 +1,5 @@
 require "t/version"
+require "t/activity_words"
 
 module T
   DATA_FILE = ENV["T_DATA_FILE"] || File.join(ENV['HOME'], ".t.csv")
@@ -7,4 +8,8 @@ module T
   TIME_FORMAT = "%Y-%m-%d %H:%M"
 
   DEFAULT_SPARKS = %w(▁ ▂ ▃ ▄ ▅ ▆ ▇ )
+
+  def self.activity_words
+    @activity_words ||= T::ActivityWords.new
+  end
 end

--- a/lib/t/activity_words.rb
+++ b/lib/t/activity_words.rb
@@ -1,0 +1,19 @@
+module T
+  class ActivityWords
+    def initialize(options = {})
+      @config = options.fetch(:config) { ENV["T_WORDS"] }
+    end
+
+    def noun
+      "work"
+    end
+
+    def present_participle
+      "working"
+    end
+
+    def past_participle
+      "worked"
+    end
+  end
+end

--- a/lib/t/activity_words.rb
+++ b/lib/t/activity_words.rb
@@ -1,19 +1,13 @@
 module T
   class ActivityWords
     def initialize(options = {})
-      @config = options.fetch(:config) { ENV["T_WORDS"] }
+      config = options.fetch(:config) { ENV["T_WORDS"] }
+      parts = config.to_s.split(":")
+      @noun               = parts[0] || "work"
+      @past_participle    = parts[1] || (@noun + "ed")
+      @present_participle = parts[2] || (@noun + "ing")
     end
 
-    def noun
-      "work"
-    end
-
-    def present_participle
-      "working"
-    end
-
-    def past_participle
-      "worked"
-    end
+    attr_reader :noun, :present_participle, :past_participle
   end
 end

--- a/lib/t/commands/pto.rb
+++ b/lib/t/commands/pto.rb
@@ -8,6 +8,7 @@ module T
       def initialize(options = {})
         @stdout = options.fetch(:out) { $stdout }
         @file   = options.fetch(:file) { T::DATA_FILE }
+        @act    = options.fetch(:act) { T.activity_words }
       end
 
       def legend_type
@@ -22,9 +23,10 @@ module T
 
         each_week do |week_start, week_end, entries|
           minutes_on = entries.inject(0) { |total, entry| total + entry.minutes_between(week_start, week_end) }
+          next if minutes_on == 0
           minutes_off = [full_week - minutes_on, 0].max
           year_totals[week_start.year] += minutes_off
-          @stdout.printf "%s work=%4d pto=%4d\n",
+          @stdout.printf "%s #{@act.noun}=%4d pto=%4d\n",
             week_start.strftime(T::DATE_FORMAT), minutes_on, minutes_off
         end
 

--- a/lib/t/commands/since.rb
+++ b/lib/t/commands/since.rb
@@ -8,6 +8,7 @@ module T
         @stdout = options.fetch(:out) { $stdout }
         @file   = options.fetch(:file) { T::DATA_FILE }
         @time   = options.fetch(:time) { Time }
+        @act    = options.fetch(:act) { T.activity_words }
       end
 
       def run
@@ -15,9 +16,9 @@ module T
         now = @time.now.strftime(T::TIME_FORMAT)
         total = data.entries.each { |e| e.stop ||= now }.inject(0) { |sum, e| sum + e.minutes_between(range_start, range_stop) }
         if total == 0
-          @stdout.puts "You have not worked #{period_description}."
+          @stdout.puts "You have not #{@act.past_participle} #{period_description}."
         else
-          @stdout.puts "You have worked for #{total} minutes #{period_description}."
+          @stdout.puts "You have #{@act.past_participle} for #{total} minutes #{period_description}."
         end
       end
     end

--- a/lib/t/commands/start.rb
+++ b/lib/t/commands/start.rb
@@ -8,6 +8,7 @@ module T
         @stdout = options.fetch(:out) { $stdout }
         @file   = options.fetch(:file) { T::DATA_FILE }
         @time   = options.fetch(:time) { Time }
+        @act    = options.fetch(:act) { T.activity_words }
       end
 
       def legend_type
@@ -17,10 +18,10 @@ module T
       def run
         data = Data.new(@file)
         if entry = data.entries.detect { |e| e.stop.nil? }
-          @stdout.puts "You already started working, at #{entry.start}!"
+          @stdout.puts "You already started #{@act.present_participle}, at #{entry.start}!"
         else
           data.start_entry(@time.now.strftime(T::TIME_FORMAT))
-          @stdout.puts "Starting work."
+          @stdout.puts "Starting #{@act.noun}."
         end
       end
     end

--- a/lib/t/commands/status.rb
+++ b/lib/t/commands/status.rb
@@ -7,6 +7,7 @@ module T
       def initialize(options = {})
         @stdout = options.fetch(:out) { $stdout }
         @file   = options.fetch(:file) { T::DATA_FILE }
+        @act    = options.fetch(:act) { T.activity_words }
       end
 
       def legend_type
@@ -16,9 +17,9 @@ module T
       def run
         data = Data.new(@file)
         if data.entries.any? { |e| e.stop.nil? }
-          @stdout.puts "WORKING"
+          @stdout.puts "#{@act.present_participle.upcase}"
         else
-          @stdout.puts "NOT working"
+          @stdout.puts "NOT #{@act.present_participle}"
         end
       end
     end

--- a/lib/t/commands/stop.rb
+++ b/lib/t/commands/stop.rb
@@ -8,6 +8,7 @@ module T
         @stdout = options.fetch(:out) { $stdout }
         @file   = options.fetch(:file) { T::DATA_FILE }
         @time   = options.fetch(:time) { Time }
+        @act    = options.fetch(:act) { T.activity_words }
       end
 
       def legend_type
@@ -21,11 +22,11 @@ module T
         when 1
           entry = started_entries.first
           data.stop_entry(entry, @time.now.strftime(T::TIME_FORMAT))
-          @stdout.puts "You just worked for #{entry.minutes} minutes."
+          @stdout.puts "You just #{@act.past_participle} for #{entry.minutes} minutes."
         when 0
-          @stdout.puts "You haven't started working yet!"
+          @stdout.puts "You haven't started #{@act.present_participle} yet!"
         else
-          @stdout.puts "Your file has more than one work session started. Please `t edit` to fix it."
+          @stdout.puts "Your file has more than one session started. Please `t edit` to fix it."
         end
       end
     end

--- a/spec/t/activity_words_spec.rb
+++ b/spec/t/activity_words_spec.rb
@@ -10,4 +10,25 @@ describe T::ActivityWords do
     it { expect(subject.past_participle).to eq("worked") }
     it { expect(subject.present_participle).to eq("working") }
   end
+
+  context "override with just a noun" do
+    let(:config) { "play" }
+    it { expect(subject.noun).to eq("play") }
+    it { expect(subject.past_participle).to eq("played") }
+    it { expect(subject.present_participle).to eq("playing") }
+  end
+
+  context "override with a noun and past participle" do
+    let(:config) { "play:faked" }
+    it { expect(subject.noun).to eq("play") }
+    it { expect(subject.past_participle).to eq("faked") }
+    it { expect(subject.present_participle).to eq("playing") }
+  end
+
+  context "override all the words" do
+    let(:config) { "play:faked:sneezing" }
+    it { expect(subject.noun).to eq("play") }
+    it { expect(subject.past_participle).to eq("faked") }
+    it { expect(subject.present_participle).to eq("sneezing") }
+  end
 end

--- a/spec/t/activity_words_spec.rb
+++ b/spec/t/activity_words_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+require "t/activity_words"
+
+describe T::ActivityWords do
+  subject { described_class.new(:config => config) }
+
+  context "defaults" do
+    let(:config) { nil }
+    it { expect(subject.noun).to eq("work") }
+    it { expect(subject.past_participle).to eq("worked") }
+    it { expect(subject.present_participle).to eq("working") }
+  end
+end

--- a/spec/t/commands/stop_spec.rb
+++ b/spec/t/commands/stop_spec.rb
@@ -66,7 +66,7 @@ E_T
 E_T
       command.run
     end
-    it { expect(stdout.string).to eq("Your file has more than one work session started. Please `t edit` to fix it.\n") }
+    it { expect(stdout.string).to eq("Your file has more than one session started. Please `t edit` to fix it.\n") }
     it { expect(File.read(t_file)).to eq(<<E_T) }
 2013-09-08 10:45,
 2013-09-08 11:55,


### PR DESCRIPTION
I'm setting up time tracking for my kids' video games. It's silly for it to say "work". Here's the wrapper script:

```{ bash /usr/local/bin/video-games }
#!/bin/sh
export T_DATA_FILE=~/Dropbox/self/t-video-games.csv
export T_WORDS=play
unset RBENV_VERSION
cd ~/dev/t
exec ./bin/t "$@"
```

```
$ video-games today
You have played for 144 minutes today.
8h=480m
```

sick days