### PR TITLE
Eliminate global variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test bench fmt release
+.PHONY: test bench release clippy
 
 SRCS = $(shell find src -name '*.rs')
 
@@ -29,10 +29,7 @@ target/release/t: $(SRCS) Cargo.toml Cargo.lock
 bench: target/debug/bench-parse target/debug/bench-sum
 	bash bench.sh
 
-fmt:
-	rustfmt -l $(SRCS)
-
-clippy: fmt
+clippy:
 	cargo clippy
 
 target/debug/%: $(SRCS)

--- a/src/bin/bench-parse.rs
+++ b/src/bin/bench-parse.rs
@@ -2,10 +2,11 @@
 //  puts T::Data.new(ENV["T_DATA_FILE"]).entries.size
 
 use t::parser::parse_entries;
+use t::timesource::real_time::DefaultTimeSource;
 
 fn main() {
     let data_file = std::env::var("T_DATA_FILE").unwrap();
     let f = std::fs::File::open(data_file).unwrap();
-    let entries = parse_entries(f).unwrap();
+    let entries = parse_entries(f, &DefaultTimeSource).unwrap();
     println!("{}", entries.len());
 }

--- a/src/bin/bench-sum.rs
+++ b/src/bin/bench-sum.rs
@@ -2,13 +2,14 @@
 //  puts T::Data.new(ENV["T_DATA_FILE"]).entries.inject(0) { |sum, e| sum + e.minutes }
 
 use t::parser::parse_entries;
+use t::timesource::real_time::DefaultTimeSource;
 
 fn main() {
     let data_file = std::env::var("T_DATA_FILE").unwrap();
     let f = std::fs::File::open(data_file).unwrap();
-    let entries = parse_entries(f).unwrap();
+    let entries = parse_entries(f, &DefaultTimeSource).unwrap();
     let sum = entries
         .into_iter()
-        .fold(0, |sum, entry| sum + entry.minutes());
+        .fold(0, |sum, entry| sum + entry.minutes(&DefaultTimeSource));
     println!("{}", sum);
 }

--- a/src/bin/count-entries-per-week.rs
+++ b/src/bin/count-entries-per-week.rs
@@ -1,12 +1,13 @@
 use t::entry::Entry;
 use t::parser::parse_entries;
+use t::timesource::real_time::DefaultTimeSource;
 use time::Date;
 use time::Weekday::Sunday;
 
 fn main() {
     let data_file = std::env::var("T_DATA_FILE").unwrap();
     let f = std::fs::File::open(data_file).unwrap();
-    let entries = parse_entries(f).unwrap();
+    let entries = parse_entries(f, &DefaultTimeSource).unwrap();
     let mut counter = Counter {
         start: None,
         count: 0,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -43,10 +43,7 @@ impl Entry {
     }
 
     pub fn stop_date(&self) -> Option<Date> {
-        match &self.stop {
-            None => None,
-            Some(t) => Some(t.wrapped.date()),
-        }
+        self.stop.as_ref().map(|t| t.wrapped.date())
     }
 
     pub fn is_finished(&self) -> bool {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -10,11 +10,6 @@ pub struct Entry {
     pub stop: Option<Time>,
 }
 
-// ok for test and prod.
-fn explicit_offset(minutes: i16) -> time::UtcOffset {
-    time::UtcOffset::minutes(minutes)
-}
-
 impl Entry {
     pub fn start<TS: TimeSource>(ts: &TS) -> Self {
         Self {
@@ -190,7 +185,7 @@ impl Time {
     ) -> Result<Self, Box<dyn Error>> {
         let date = time::Date::try_from_ymd(year as i32, month, day)?;
         let time = time::Time::try_from_hms(hour, minute, 0)?;
-        let offset = utc_offset.map(explicit_offset);
+        let offset = utc_offset.map(time::UtcOffset::minutes);
         Ok(Self::from_dto(date, time, offset, ts))
     }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -13,7 +13,7 @@ pub struct Entry {
 impl Entry {
     pub fn start<TS: TimeSource>(ts: &TS) -> Self {
         Self {
-            start: Time::now(ts),
+            start: Time::at(ts.now()),
             stop: None,
         }
     }
@@ -33,7 +33,7 @@ impl Entry {
             panic!("finish called for a finished entry! {}", self);
         }
         Self {
-            stop: Some(Time::now(ts)),
+            stop: Some(Time::at(ts.now())),
             ..self
         }
     }
@@ -157,13 +157,6 @@ pub struct Time {
 }
 
 impl Time {
-    pub fn now<TS: TimeSource>(ts: &TS) -> Self {
-        Self {
-            wrapped: ts.now(),
-            implied_tz: false,
-        }
-    }
-
     pub fn at(wrapped: OffsetDateTime) -> Self {
         Self {
             wrapped,
@@ -231,8 +224,8 @@ impl Display for Time {
 #[cfg(test)]
 mod tests {
     use super::{Entry, Time};
-    use crate::timesource::mock_time::mock_time;
     use crate::timesource::real_time::DefaultTimeSource;
+    use crate::timesource::{mock_time::mock_time, TimeSource};
     use time::{date, offset, time, PrimitiveDateTime};
 
     type TestRes = Result<(), Box<dyn std::error::Error>>;
@@ -272,9 +265,9 @@ mod tests {
     }
 
     #[test]
-    fn test_now() {
+    fn test_at() {
         let ts = mock_time(date!(2020 - 07 - 15), time!(11:23), offset!(+11:00));
-        let time = Time::now(&ts);
+        let time = Time::at(ts.now());
         assert_eq!("2020-07-15 11:23 +1100", format!("{}", time));
     }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -239,7 +239,7 @@ impl Display for Time {
 #[cfg(test)]
 mod tests {
     use super::{Entry, Time};
-    use crate::timesource::mock_time::{set_mock_time, MockTimeSource};
+    use crate::timesource::mock_time::mock_time;
     use crate::timesource::real_time::DefaultTimeSource;
     use time::{date, offset, time, PrimitiveDateTime};
 
@@ -281,8 +281,8 @@ mod tests {
 
     #[test]
     fn test_now() {
-        set_mock_time(date!(2020 - 07 - 15), time!(11:23), offset!(+11:00));
-        let time = Time::now(&MockTimeSource);
+        let ts = mock_time(date!(2020 - 07 - 15), time!(11:23), offset!(+11:00));
+        let time = Time::now(&ts);
         assert_eq!("2020-07-15 11:23 +1100", format!("{}", time));
     }
 
@@ -298,23 +298,23 @@ mod tests {
 
     #[test]
     fn test_minutes_no_stop() -> TestRes {
-        set_mock_time(date!(2020 - 06 - 20), time!(1:55), offset!(-02:00));
+        let ts = mock_time(date!(2020 - 06 - 20), time!(1:55), offset!(-02:00));
         let entry = Entry {
-            start: Time::new(2020, 6, 20, 1, 7, Some(120), &MockTimeSource)?,
+            start: Time::new(2020, 6, 20, 1, 7, Some(120), &ts)?,
             stop: None,
         };
-        assert_eq!(4 * 60 + 48, entry.minutes(&MockTimeSource));
+        assert_eq!(4 * 60 + 48, entry.minutes(&ts));
         Ok(())
     }
 
     #[test]
     fn test_minutes_no_stop_no_tz() -> TestRes {
-        set_mock_time(date!(2020 - 06 - 20), time!(1:55), offset!(+02:00));
+        let ts = mock_time(date!(2020 - 06 - 20), time!(1:55), offset!(+02:00));
         let entry = Entry {
-            start: Time::new(2020, 6, 20, 1, 7, None, &MockTimeSource)?,
+            start: Time::new(2020, 6, 20, 1, 7, None, &ts)?,
             stop: None,
         };
-        assert_eq!(48, entry.minutes(&MockTimeSource));
+        assert_eq!(48, entry.minutes(&ts));
         Ok(())
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -382,11 +382,11 @@ pub fn t_data_file() -> Result<String, std::env::VarError> {
 }
 
 // If there isn't a pending entry, start a new one.
-pub fn start_new_entry<TS: TimeSource + Clone>(ts: &TS) -> Result<Option<i64>, Box<dyn Error>> {
+pub fn start_new_entry<TS: TimeSource>(ts: &TS) -> Result<Option<i64>, Box<dyn Error>> {
     _start_new_entry(t_data_file()?, ts)
 }
 
-fn _start_new_entry<P: AsRef<Path>, TS: TimeSource + Clone>(
+fn _start_new_entry<P: AsRef<Path>, TS: TimeSource>(
     t_data_file: P,
     ts: &TS,
 ) -> Result<Option<i64>, Box<dyn Error>> {
@@ -402,11 +402,11 @@ fn _start_new_entry<P: AsRef<Path>, TS: TimeSource + Clone>(
 }
 
 // If there is a pending entry, finish it.
-pub fn stop_current_entry<TS: TimeSource + Clone>(ts: &TS) -> Result<Option<i64>, Box<dyn Error>> {
+pub fn stop_current_entry<TS: TimeSource>(ts: &TS) -> Result<Option<i64>, Box<dyn Error>> {
     _stop_current_entry(t_data_file()?, ts)
 }
 
-fn _stop_current_entry<P: AsRef<Path>, TS: TimeSource + Clone>(
+fn _stop_current_entry<P: AsRef<Path>, TS: TimeSource>(
     t_data_file: P,
     ts: &TS,
 ) -> Result<Option<i64>, Box<dyn Error>> {
@@ -430,7 +430,7 @@ type ReadResult = (File, Option<Entry>, u64, u64);
 
 // Get the last entry from the file, along with its start and stop
 // positions.
-fn read_for_update<P: AsRef<Path>, TS: TimeSource + Clone>(
+fn read_for_update<P: AsRef<Path>, TS: TimeSource>(
     t_data_file: P,
     ts: &TS,
 ) -> Result<ReadResult, Box<dyn Error>> {
@@ -460,18 +460,15 @@ fn read_for_update<P: AsRef<Path>, TS: TimeSource + Clone>(
     Ok((f, last_entry, start_pos, stop_pos))
 }
 
-pub fn read_entries<TS: TimeSource + Clone>(ts: &TS) -> Result<Vec<Entry>, Box<dyn Error>> {
+pub fn read_entries<TS: TimeSource>(ts: &TS) -> Result<Vec<Entry>, Box<dyn Error>> {
     t_open(t_data_file()?)?.read_entries(ts)
 }
 
-pub fn read_last_entry<TS: TimeSource + Clone>(ts: &TS) -> Result<Option<Entry>, Box<dyn Error>> {
+pub fn read_last_entry<TS: TimeSource>(ts: &TS) -> Result<Option<Entry>, Box<dyn Error>> {
     t_open(t_data_file()?)?.read_last_entry(ts)
 }
 
-pub fn read_last_entries<TS: TimeSource + Clone>(
-    n: u64,
-    ts: &TS,
-) -> Result<Vec<Entry>, Box<dyn Error>> {
+pub fn read_last_entries<TS: TimeSource>(n: u64, ts: &TS) -> Result<Vec<Entry>, Box<dyn Error>> {
     t_open(t_data_file()?)?.read_last_entries(n, ts)
 }
 
@@ -490,21 +487,18 @@ struct TFile {
 }
 
 impl TFile {
-    fn read_entries<TS: TimeSource + Clone>(self, ts: &TS) -> Result<Vec<Entry>, Box<dyn Error>> {
+    fn read_entries<TS: TimeSource>(self, ts: &TS) -> Result<Vec<Entry>, Box<dyn Error>> {
         match self.f {
             Some(f) => parse_entries(f, ts),
             None => Ok(vec![]),
         }
     }
 
-    fn read_last_entry<TS: TimeSource + Clone>(
-        self,
-        ts: &TS,
-    ) -> Result<Option<Entry>, Box<dyn Error>> {
+    fn read_last_entry<TS: TimeSource>(self, ts: &TS) -> Result<Option<Entry>, Box<dyn Error>> {
         Ok(self.read_last_entries(1, ts)?.into_iter().last())
     }
 
-    fn read_last_entries<TS: TimeSource + Clone>(
+    fn read_last_entries<TS: TimeSource>(
         self,
         n: u64,
         ts: &TS,

--- a/src/file.rs
+++ b/src/file.rs
@@ -11,7 +11,7 @@ const APPROX_LINE_LENGTH_FOR_SEEK: u64 = 50;
 #[cfg(test)]
 mod tests {
     use crate::entry::Entry;
-    use crate::timesource::mock_time::{set_mock_time, MockTimeSource};
+    use crate::timesource::mock_time::mock_time;
     use crate::timesource::real_time::DefaultTimeSource;
     use std::error::Error;
     use std::fs::File;
@@ -63,36 +63,27 @@ mod tests {
 
     #[test]
     fn test_start_in_new_file() -> TestRes {
-        set_mock_time(date!(2020 - 07 - 15), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 07 - 15), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(None)?;
-        assert_eq!(
-            None,
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(None, super::_start_new_entry(fixt.t_data_file(), &ts)?);
         assert_eq!("2020-07-15 10:23 -0400\n", fixt.read()?);
         Ok(())
     }
 
     #[test]
     fn test_start_in_empty_file() -> TestRes {
-        set_mock_time(date!(2020 - 07 - 15), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 07 - 15), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(Some("empty.csv"))?;
-        assert_eq!(
-            None,
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(None, super::_start_new_entry(fixt.t_data_file(), &ts)?);
         assert_eq!("2020-07-15 10:23 -0400\n", fixt.read()?);
         Ok(())
     }
 
     #[test]
     fn test_start_in_file_with_entries() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(Some("three-entries.csv"))?;
-        assert_eq!(
-            None,
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(None, super::_start_new_entry(fixt.t_data_file(), &ts)?);
         assert_eq!(
             "2020-08-06 15:38 -0400,2020-08-06 18:40 -0400\n\
                     2020-08-07 11:03 -0400,2020-08-07 13:07 -0400\n\
@@ -105,45 +96,30 @@ mod tests {
 
     #[test]
     fn test_start_twice() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(None)?;
-        assert_eq!(
-            None,
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
-        assert_eq!(
-            Some(0),
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
-        set_mock_time(date!(2020 - 08 - 08), time!(10:34), offset!(-04:00));
-        assert_eq!(
-            Some(11),
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(None, super::_start_new_entry(fixt.t_data_file(), &ts)?);
+        assert_eq!(Some(0), super::_start_new_entry(fixt.t_data_file(), &ts)?);
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:34), offset!(-04:00));
+        assert_eq!(Some(11), super::_start_new_entry(fixt.t_data_file(), &ts)?);
         assert_eq!("2020-08-08 10:23 -0400\n", fixt.read()?);
         Ok(())
     }
 
     #[test]
     fn test_start_with_blank_lines() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(Some("blank-lines.csv"))?;
-        assert_eq!(
-            None,
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(None, super::_start_new_entry(fixt.t_data_file(), &ts)?);
         assert_eq!("2020-08-08 10:23 -0400\n", fixt.read()?);
         Ok(())
     }
 
     #[test]
     fn test_start_with_entry_and_trailing_whitespace() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(Some("entry-with-trailing-blank-lines.csv"))?;
-        assert_eq!(
-            None,
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(None, super::_start_new_entry(fixt.t_data_file(), &ts)?);
         assert_eq!(
             "2020-08-06 14:00 -0400,2020-08-06 17:55 -0400\n\
                     \n\
@@ -156,34 +132,31 @@ mod tests {
 
     #[test]
     fn test_start_when_entry_has_comma() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(Some("started-with-comma.csv"))?;
         assert_eq!(
             Some(1223),
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_start_new_entry(fixt.t_data_file(), &ts)?
         );
         Ok(())
     }
 
     #[test]
     fn test_start_when_entry_has_no_comma() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 08), time!(10:23), offset!(-04:00));
         let fixt = Fixture::new(Some("started-no-comma.csv"))?;
         assert_eq!(
             Some(1223),
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_start_new_entry(fixt.t_data_file(), &ts)?
         );
         Ok(())
     }
 
     #[test]
     fn test_start_when_two_entries_are_pending() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
         let fixt = Fixture::new(Some("two-started-entries.csv"))?;
-        assert_eq!(
-            Some(83),
-            super::_start_new_entry(fixt.t_data_file(), &MockTimeSource)?
-        );
+        assert_eq!(Some(83), super::_start_new_entry(fixt.t_data_file(), &ts)?);
         Ok(())
     }
 
@@ -192,7 +165,7 @@ mod tests {
         let fixt = Fixture::new(None)?;
         assert_eq!(
             None,
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &DefaultTimeSource)?
         );
         Ok(())
     }
@@ -202,7 +175,7 @@ mod tests {
         let fixt = Fixture::new(Some("empty.csv"))?;
         assert_eq!(
             None,
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &DefaultTimeSource)?
         );
         Ok(())
     }
@@ -212,18 +185,18 @@ mod tests {
         let fixt = Fixture::new(Some("three-entries.csv"))?;
         assert_eq!(
             None,
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &DefaultTimeSource)?
         );
         Ok(())
     }
 
     #[test]
     fn test_stop_when_entry_has_comma() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
         let fixt = Fixture::new(Some("started-with-comma.csv"))?;
         assert_eq!(
             Some(83),
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &ts)?
         );
         assert_eq!(
             "2020-08-07 14:00 -0400,2020-08-07 15:23 -0400\n",
@@ -234,11 +207,11 @@ mod tests {
 
     #[test]
     fn test_stop_when_entry_has_no_comma() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
         let fixt = Fixture::new(Some("started-no-comma.csv"))?;
         assert_eq!(
             Some(83),
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &ts)?
         );
         assert_eq!(
             "2020-08-07 14:00 -0400,2020-08-07 15:23 -0400\n",
@@ -249,11 +222,11 @@ mod tests {
 
     #[test]
     fn test_stop_when_entry_has_trailing_blank_lines() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
         let fixt = Fixture::new(Some("started-trailing-blank-lines.csv"))?;
         assert_eq!(
             Some(83),
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &ts)?
         );
         assert_eq!("2020-08-07 14:00,2020-08-07 15:23 -0400\n", fixt.read()?);
         Ok(())
@@ -261,11 +234,11 @@ mod tests {
 
     #[test]
     fn test_stop_when_two_entries_are_pending() -> TestRes {
-        set_mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
+        let ts = mock_time(date!(2020 - 08 - 07), time!(15:23), offset!(-04:00));
         let fixt = Fixture::new(Some("two-started-entries.csv"))?;
         assert_eq!(
             Some(83),
-            super::_stop_current_entry(fixt.t_data_file(), &MockTimeSource)?
+            super::_stop_current_entry(fixt.t_data_file(), &ts)?
         );
         Ok(())
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -9,7 +9,8 @@ const APPROX_LINE_LENGTH_FOR_SEEK: u64 = 50;
 
 #[cfg(test)]
 mod tests {
-    use crate::entry::{mock_time::*, Entry};
+    use crate::entry::Entry;
+    use crate::timesource::mock_time::set_mock_time;
     use std::error::Error;
     use std::fs::File;
     use std::io::Read;

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,6 +1,6 @@
 use crate::entry::Entry;
 use crate::parser::{parse_entries, parse_entry};
-use crate::timesource::{real_time::DefaultTimeSource, TimeSource};
+use crate::timesource::TimeSource;
 use std::error::Error;
 use std::fs::{File, OpenOptions};
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
@@ -377,8 +377,8 @@ pub fn t_data_file() -> Result<String, std::env::VarError> {
 }
 
 // If there isn't a pending entry, start a new one.
-pub fn start_new_entry() -> Result<Option<i64>, Box<dyn Error>> {
-    _start_new_entry(t_data_file()?, &DefaultTimeSource)
+pub fn start_new_entry<TS: TimeSource>(ts: &TS) -> Result<Option<i64>, Box<dyn Error>> {
+    _start_new_entry(t_data_file()?, ts)
 }
 
 fn _start_new_entry<P: AsRef<Path>, TS: TimeSource>(
@@ -397,8 +397,8 @@ fn _start_new_entry<P: AsRef<Path>, TS: TimeSource>(
 }
 
 // If there is a pending entry, finish it.
-pub fn stop_current_entry() -> Result<Option<i64>, Box<dyn Error>> {
-    _stop_current_entry(t_data_file()?, &DefaultTimeSource)
+pub fn stop_current_entry<TS: TimeSource>(ts: &TS) -> Result<Option<i64>, Box<dyn Error>> {
+    _stop_current_entry(t_data_file()?, ts)
 }
 
 fn _stop_current_entry<P: AsRef<Path>, TS: TimeSource>(

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -10,15 +10,13 @@ pub fn filter_entries(
 
 fn build_filter(filters: Vec<String>) -> Result<Filter, &'static str> {
     match filters.len() {
-        0 => Ok(Filter::NoFilter),
+        0 => Ok(Filter::None),
         1 => {
-            filters[0]
-                .split("-")
-                .fold(Ok(Filter::NoFilter), |res, part| {
-                    res.and_then(|v| v.add_part(part))
-                })
+            filters[0].split('-').fold(Ok(Filter::None), |res, part| {
+                res.and_then(|v| v.add_part(part))
+            })
             /*
-            let mut filter = Filter::NoFilter;
+            let mut filter = Filter::None;
             for part in filters[0].split("-") {
                 filter = filter.add_part(part)?;
             }
@@ -30,31 +28,31 @@ fn build_filter(filters: Vec<String>) -> Result<Filter, &'static str> {
 }
 
 enum Filter {
-    NoFilter,
-    YearFilter(i32),
-    YearMonthFilter(i32, u8),
+    None,
+    ByYear(i32),
+    ByYearMonth(i32, u8),
 }
 
 impl Filter {
     fn filter(&self, entry: &Entry) -> bool {
         match self {
-            Filter::NoFilter => true,
-            Filter::YearFilter(year) => entry.includes_year(*year),
-            Filter::YearMonthFilter(year, month) => entry.includes_year_month(*year, *month),
+            Filter::None => true,
+            Filter::ByYear(year) => entry.includes_year(*year),
+            Filter::ByYearMonth(year, month) => entry.includes_year_month(*year, *month),
         }
     }
 
     fn add_part(self, part: &str) -> Result<Self, &'static str> {
         match self {
-            Filter::NoFilter => part
+            Filter::None => part
                 .parse()
-                .and_then(|y| Ok(Filter::YearFilter(y)))
+                .map(Filter::ByYear)
                 .or(Err("couldn't parse year")),
-            Filter::YearFilter(y) => part
+            Filter::ByYear(y) => part
                 .parse()
-                .and_then(|m| Ok(Filter::YearMonthFilter(y, m)))
+                .map(|m| Filter::ByYearMonth(y, m))
                 .or(Err("couldn't parse month")),
-            Filter::YearMonthFilter(_, _) => Err("only YYYY or YYYY-MM filters are supported"),
+            Filter::ByYearMonth(_, _) => Err("only YYYY or YYYY-MM filters are supported"),
         }
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,5 @@
-use crate::entry::{now, Entry};
+use crate::entry::Entry;
+use crate::timesource::now;
 use time::{Date, Duration, OffsetDateTime, Weekday::*};
 
 pub fn each_week(entries: Vec<Entry>) -> DaysIterator {
@@ -117,8 +118,8 @@ impl Iterator for WeekOfDaysIterator {
 
 #[cfg(test)]
 mod tests {
-    use crate::entry::mock_time::*;
     use crate::parser::parse_entries;
+    use crate::timesource::mock_time::set_mock_time;
     use pretty_assertions::assert_eq;
     use time::{date, offset, time};
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,5 @@
 use crate::entry::Entry;
-use crate::timesource::{now, real_time::DefaultTimeSource, TimeSource};
+use crate::timesource::{real_time::DefaultTimeSource, TimeSource};
 use time::{Date, Duration, OffsetDateTime, Weekday::*};
 
 pub fn each_week(entries: Vec<Entry>) -> DaysIterator {
@@ -22,7 +22,7 @@ fn each_day(entries: Vec<Entry>) -> DaysIterator {
         days: 1,
         last_date: None,
         next_index: 0,
-        now: now(),
+        now: DefaultTimeSource.now(),
     }
 }
 
@@ -60,7 +60,11 @@ impl Iterator for DaysIterator {
                     break;
                 } else {
                     entries.push(entry.clone().finish_if_not(self.now));
-                    if entry.stop_date() >= next_date {
+                    let st = match entry.try_stop_date() {
+                        None => self.now.date(),
+                        Some(d) => d,
+                    };
+                    if st >= next_date {
                         break;
                     }
                     self.next_index += 1;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -127,7 +127,7 @@ impl Iterator for WeekOfDaysIterator {
 #[cfg(test)]
 mod tests {
     use crate::parser::parse_entries;
-    use crate::timesource::mock_time::{set_mock_time, MockTimeSource};
+    use crate::timesource::mock_time::mock_time;
     use crate::timesource::real_time::DefaultTimeSource;
     use pretty_assertions::assert_eq;
     use time::{date, offset, time};
@@ -290,13 +290,13 @@ mod tests {
 
     #[test]
     fn test_each_week_current_entry_in_progress() -> TestRes {
-        set_mock_time(date!(2020 - 01 - 15), time!(11:00), offset!(-04:00));
-        let entries = parse_entries("2020-01-15 10:10 -0400".as_bytes(), &MockTimeSource)?;
+        let ts = mock_time(date!(2020 - 01 - 15), time!(11:00), offset!(-04:00));
+        let entries = parse_entries("2020-01-15 10:10 -0400".as_bytes(), &ts)?;
         let expected_entries = parse_entries(
             "2020-01-15 10:10 -0400,2020-01-15 11:00 -0400".as_bytes(),
-            &MockTimeSource,
+            &ts,
         )?;
-        let mut i = super::each_week(entries.clone(), &MockTimeSource);
+        let mut i = super::each_week(entries.clone(), &ts);
         assert_eq!(Some((date!(2020 - 01 - 12), expected_entries)), i.next());
         assert_eq!(None, i.next());
         Ok(())

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -60,7 +60,7 @@ impl Iterator for DaysIterator {
                     break;
                 } else {
                     entries.push(entry.clone().finish_if_not(self.now));
-                    let st = match entry.try_stop_date() {
+                    let st = match entry.stop_date() {
                         None => self.now.date(),
                         Some(d) => d,
                     };
@@ -152,6 +152,7 @@ mod tests {
             "2020-08-02 10:10,2020-08-02 11:10\n\
              2020-08-08 10:10,2020-08-08 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i = super::each_week(entries.clone(), &DefaultTimeSource);
         assert_eq!(Some((date!(2020 - 08 - 02), entries)), i.next());
@@ -165,6 +166,7 @@ mod tests {
             "2020-08-02 10:10,2020-08-02 11:10\n\
              2020-08-02 10:10,2020-08-02 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i = super::each_day(entries.clone(), &DefaultTimeSource);
         assert_eq!(Some((date!(2020 - 08 - 02), entries)), i.next());
@@ -178,6 +180,7 @@ mod tests {
             "2020-08-02 10:10,2020-08-02 11:10\n\
              2020-09-02 10:10,2020-09-02 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i = super::each_week(entries.clone(), &DefaultTimeSource);
         assert_eq!(
@@ -198,6 +201,7 @@ mod tests {
             "2020-08-02 10:10,2020-08-02 11:10\n\
              2020-08-05 10:10,2020-08-05 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i = super::each_day(entries.clone(), &DefaultTimeSource);
         assert_eq!(
@@ -218,6 +222,7 @@ mod tests {
              2020-08-08 10:10,2020-08-09 11:10\n\
              2020-09-02 10:10,2020-09-02 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i = super::each_week(entries.clone(), &DefaultTimeSource);
         assert_eq!(
@@ -248,6 +253,7 @@ mod tests {
              2020-08-02 12:10,2020-08-03 11:10\n\
              2020-08-05 10:10,2020-08-05 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i = super::each_day(entries.clone(), &DefaultTimeSource);
         assert_eq!(
@@ -272,7 +278,10 @@ mod tests {
 
     #[test]
     pub fn test_each_week_first_entry_not_sunday() -> TestRes {
-        let entries = parse_entries("2020-08-08 10:10,2020-08-08 11:10\n".as_bytes())?;
+        let entries = parse_entries(
+            "2020-08-08 10:10,2020-08-08 11:10\n".as_bytes(),
+            &DefaultTimeSource,
+        )?;
         let mut i = super::each_week(entries.clone(), &DefaultTimeSource);
         assert_eq!(Some((date!(2020 - 08 - 02), entries)), i.next());
         assert_eq!(None, i.next());
@@ -282,9 +291,11 @@ mod tests {
     #[test]
     fn test_each_week_current_entry_in_progress() -> TestRes {
         set_mock_time(date!(2020 - 01 - 15), time!(11:00), offset!(-04:00));
-        let entries = parse_entries("2020-01-15 10:10 -0400".as_bytes())?;
-        let expected_entries =
-            parse_entries("2020-01-15 10:10 -0400,2020-01-15 11:00 -0400".as_bytes())?;
+        let entries = parse_entries("2020-01-15 10:10 -0400".as_bytes(), &MockTimeSource)?;
+        let expected_entries = parse_entries(
+            "2020-01-15 10:10 -0400,2020-01-15 11:00 -0400".as_bytes(),
+            &MockTimeSource,
+        )?;
         let mut i = super::each_week(entries.clone(), &MockTimeSource);
         assert_eq!(Some((date!(2020 - 01 - 12), expected_entries)), i.next());
         assert_eq!(None, i.next());
@@ -300,6 +311,7 @@ mod tests {
              2020-08-05 10:10,2020-08-05 11:10\n\
              2020-08-08 10:10,2020-08-11 11:10\n"
                 .as_bytes(),
+            &DefaultTimeSource,
         )?;
         let mut i =
             super::each_day_in_week(entries.clone(), date!(2020 - 08 - 03), &DefaultTimeSource);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod filter;
 pub mod iter;
 pub mod parser;
 pub mod report;
+mod timesource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@ pub mod filter;
 pub mod iter;
 pub mod parser;
 pub mod report;
-mod timesource;
+pub mod timesource;

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn usage() -> ! {
 
 fn cmd_start() {
     cmd_validate();
-    match start_new_entry().unwrap() {
+    match start_new_entry(&TIME_SOURCE).unwrap() {
         None => println!("Starting work."),
         Some(minutes) => println!("You already started working, {} minutes ago!", minutes),
     };
@@ -109,7 +109,7 @@ fn cmd_start() {
 
 fn cmd_stop() {
     cmd_validate();
-    match stop_current_entry().unwrap() {
+    match stop_current_entry(&TIME_SOURCE).unwrap() {
         Some(minutes) => println!("You just worked for {} minutes.", minutes),
         None => println!("You haven't started working yet!"),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn cmd_edit() -> ! {
 }
 
 fn cmd_status(args: StatusArgs) -> bool {
-    let entries = read_last_entries(100).expect("error parsing data file");
+    let entries = read_last_entries(100, &TIME_SOURCE).expect("error parsing data file");
     let working = match entries.last() {
         None => false,
         Some(e) => e.stop.is_none(),
@@ -178,7 +178,7 @@ fn show_bitbar_plugin(mut wrapper: &str) {
 fn cmd_today() {
     let (start_today, now) = extents::today();
     // longest week so far is 46 entries, so 100 should be totally fine for a day.
-    let entries = read_last_entries(100).expect("error parsing data file");
+    let entries = read_last_entries(100, &TIME_SOURCE).expect("error parsing data file");
     let minutes = minutes_between(&entries, start_today, now);
     println!("You have worked for {} minutes today.", minutes);
     print_day_legend();
@@ -187,7 +187,7 @@ fn cmd_today() {
 fn cmd_week() {
     let (start_week, now) = extents::this_week();
     // longest week so far is 46 entries, so 100 should be totally fine.
-    let entries = read_last_entries(100).expect("error parsing data file");
+    let entries = read_last_entries(100, &TIME_SOURCE).expect("error parsing data file");
     let minutes = minutes_between(&entries, start_week, now);
     println!(
         "You have worked for {} minutes since {}.",
@@ -198,7 +198,7 @@ fn cmd_week() {
 }
 
 fn cmd_all() {
-    let entries = read_entries().expect("error parsing data file");
+    let entries = read_entries(&TIME_SOURCE).expect("error parsing data file");
     for line in report::all::calc(entries, &DEFAULT_SPARKS, &TIME_SOURCE) {
         let week_end = line.start + Duration::days(6);
         print!("{} - {}   {:4} min", line.start, week_end, line.minutes);
@@ -233,7 +233,7 @@ let width = match term_size::dimensions() {
 */
 
 fn cmd_days(args: DaysArgs) {
-    let entries = read_entries().expect("error parsing data file");
+    let entries = read_entries(&TIME_SOURCE).expect("error parsing data file");
     let entries = filter_entries(entries, args.filters).expect("unusable filter");
     print!("{}", report::days::prepare(entries, &TIME_SOURCE));
     print_week_legend();
@@ -245,7 +245,7 @@ fn cmd_path() {
 
 fn cmd_validate() {
     let mut maybe_last_entry = None;
-    for (n, entry) in read_entries().unwrap().into_iter().enumerate() {
+    for (n, entry) in read_entries(&TIME_SOURCE).unwrap().into_iter().enumerate() {
         if let Err(err) = entry.is_valid_after(&maybe_last_entry) {
             println!("{}: {}", n, err);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ fn cmd_week() {
 
 fn cmd_all() {
     let entries = read_entries().expect("error parsing data file");
-    for line in report::all::calc(entries, &DEFAULT_SPARKS) {
+    for line in report::all::calc(entries, &DEFAULT_SPARKS, &TIME_SOURCE) {
         let week_end = line.start + Duration::days(6);
         print!("{} - {}   {:4} min", line.start, week_end, line.minutes);
         if let Some(analysis) = line.analysis {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use t::extents;
 use t::file::*;
 use t::filter::filter_entries;
 use t::report;
+use t::timesource::real_time::DefaultTimeSource;
 use time::{Duration, OffsetDateTime};
 
 const DEFAULT_SPARKS: [char; 7] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇'];
@@ -63,6 +64,8 @@ struct DaysArgs {
 
 #[derive(Options)]
 struct NoArgs {}
+
+static TIME_SOURCE: DefaultTimeSource = DefaultTimeSource;
 
 fn main() {
     let opts = MainOptions::parse_args_default_or_exit();
@@ -232,7 +235,7 @@ let width = match term_size::dimensions() {
 fn cmd_days(args: DaysArgs) {
     let entries = read_entries().expect("error parsing data file");
     let entries = filter_entries(entries, args.filters).expect("unusable filter");
-    print!("{}", report::days::prepare(entries));
+    print!("{}", report::days::prepare(entries, &TIME_SOURCE));
     print_week_legend();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ fn cmd_bitbar(args: BitBarArgs) {
 }
 
 fn show_bitbar_plugin(mut wrapper: &str) {
-    if wrapper == "" {
+    if wrapper.is_empty() {
         wrapper = "t";
     }
     let working = cmd_status(StatusArgs { with_week: true });

--- a/src/report/all.rs
+++ b/src/report/all.rs
@@ -162,7 +162,7 @@ mod tests {
                      2013-09-04 11:16,2013-09-04 11:26\n\
                      2013-09-05 11:26,2013-09-05 11:39\n\
                      2013-09-05 11:39,2013-09-05 11:49\n";
-        let entries = parse_entries(input.as_bytes())?;
+        let entries = parse_entries(input.as_bytes(), &DefaultTimeSource)?;
         let sparks = vec![0, 1, 2, 3, 4, 5, 6];
         let result = super::calc(entries, &sparks, &DefaultTimeSource);
         assert_eq!(

--- a/src/report/all.rs
+++ b/src/report/all.rs
@@ -1,6 +1,6 @@
 use crate::entry::Entry;
 use crate::iter::{each_day_in_week, each_week};
-use crate::timesource::local_offset;
+use crate::timesource::{real_time::DefaultTimeSource, TimeSource};
 use std::fmt::Debug;
 use time::{Date, Duration, OffsetDateTime};
 
@@ -42,7 +42,9 @@ fn calc_all_week<T: PartialEq + Copy>(start: Date, entries: Vec<Entry>, sparks: 
         let entry_minutes_by_day: Vec<Vec<i64>> = each_day_in_week(entries, start)
             .filter(|(_, entries)| !entries.is_empty())
             .map(|(start, entries)| {
-                let start = start.midnight().assume_offset(local_offset());
+                let start = start
+                    .midnight()
+                    .assume_offset(DefaultTimeSource.local_offset());
                 let stop = start + ONE_DAY;
                 entries
                     .into_iter()
@@ -114,8 +116,12 @@ fn minutes_between(entries: &[Entry], start: OffsetDateTime, stop: OffsetDateTim
 fn minutes_between_days(entries: &[Entry], start: Date, stop: Date) -> i64 {
     minutes_between(
         entries,
-        start.midnight().assume_offset(local_offset()),
-        stop.next_day().midnight().assume_offset(local_offset()),
+        start
+            .midnight()
+            .assume_offset(DefaultTimeSource.local_offset()),
+        stop.next_day()
+            .midnight()
+            .assume_offset(DefaultTimeSource.local_offset()),
     )
 }
 

--- a/src/report/all.rs
+++ b/src/report/all.rs
@@ -22,7 +22,7 @@ pub struct AllAnalysis<T: PartialEq> {
 }
 
 pub fn calc<T: PartialEq + Copy>(entries: Vec<Entry>, sparks: &[T]) -> Vec<All<T>> {
-    each_week(entries)
+    each_week(entries, &DefaultTimeSource)
         .map(|(start, entries)| calc_all_week(start, entries, sparks))
         .collect()
 }
@@ -39,19 +39,20 @@ fn calc_all_week<T: PartialEq + Copy>(start: Date, entries: Vec<Entry>, sparks: 
             None,
         )
     } else {
-        let entry_minutes_by_day: Vec<Vec<i64>> = each_day_in_week(entries, start)
-            .filter(|(_, entries)| !entries.is_empty())
-            .map(|(start, entries)| {
-                let start = start
-                    .midnight()
-                    .assume_offset(DefaultTimeSource.local_offset());
-                let stop = start + ONE_DAY;
-                entries
-                    .into_iter()
-                    .map(|entry| entry.minutes_between(start, stop))
-                    .collect()
-            })
-            .collect();
+        let entry_minutes_by_day: Vec<Vec<i64>> =
+            each_day_in_week(entries, start, &DefaultTimeSource)
+                .filter(|(_, entries)| !entries.is_empty())
+                .map(|(start, entries)| {
+                    let start = start
+                        .midnight()
+                        .assume_offset(DefaultTimeSource.local_offset());
+                    let stop = start + ONE_DAY;
+                    entries
+                        .into_iter()
+                        .map(|entry| entry.minutes_between(start, stop))
+                        .collect()
+                })
+                .collect();
         let entry_minutes: Vec<i64> = entry_minutes_by_day
             .iter()
             .flat_map(|entries| entries.iter().copied())

--- a/src/report/all.rs
+++ b/src/report/all.rs
@@ -1,6 +1,6 @@
 use crate::entry::Entry;
 use crate::iter::{each_day_in_week, each_week};
-use crate::timesource::{real_time::DefaultTimeSource, TimeSource};
+use crate::timesource::TimeSource;
 use std::fmt::Debug;
 use time::{Date, Duration, OffsetDateTime};
 
@@ -21,38 +21,44 @@ pub struct AllAnalysis<T: PartialEq> {
     pub sparks: Vec<Vec<T>>,
 }
 
-pub fn calc<T: PartialEq + Copy>(entries: Vec<Entry>, sparks: &[T]) -> Vec<All<T>> {
-    each_week(entries, &DefaultTimeSource)
-        .map(|(start, entries)| calc_all_week(start, entries, sparks))
+pub fn calc<T: PartialEq + Copy, TS: TimeSource>(
+    entries: Vec<Entry>,
+    sparks: &[T],
+    ts: &TS,
+) -> Vec<All<T>> {
+    each_week(entries, ts)
+        .map(|(start, entries)| calc_all_week(start, entries, sparks, ts))
         .collect()
 }
 
 const ONE_DAY: Duration = Duration::days(1);
 const SUNDAY_TO_SATURDAY: Duration = Duration::days(6);
 
-fn calc_all_week<T: PartialEq + Copy>(start: Date, entries: Vec<Entry>, sparks: &[T]) -> All<T> {
+fn calc_all_week<T: PartialEq + Copy, TS: TimeSource>(
+    start: Date,
+    entries: Vec<Entry>,
+    sparks: &[T],
+    ts: &TS,
+) -> All<T> {
     let (segments, minutes, analysis) = if entries.len() < 2 {
         let stop = start + SUNDAY_TO_SATURDAY;
         (
             entries.len(),
-            minutes_between_days(&entries, start, stop),
+            minutes_between_days(&entries, start, stop, ts),
             None,
         )
     } else {
-        let entry_minutes_by_day: Vec<Vec<i64>> =
-            each_day_in_week(entries, start, &DefaultTimeSource)
-                .filter(|(_, entries)| !entries.is_empty())
-                .map(|(start, entries)| {
-                    let start = start
-                        .midnight()
-                        .assume_offset(DefaultTimeSource.local_offset());
-                    let stop = start + ONE_DAY;
-                    entries
-                        .into_iter()
-                        .map(|entry| entry.minutes_between(start, stop))
-                        .collect()
-                })
-                .collect();
+        let entry_minutes_by_day: Vec<Vec<i64>> = each_day_in_week(entries, start, ts)
+            .filter(|(_, entries)| !entries.is_empty())
+            .map(|(start, entries)| {
+                let start = start.midnight().assume_offset(ts.local_offset());
+                let stop = start + ONE_DAY;
+                entries
+                    .into_iter()
+                    .map(|entry| entry.minutes_between(start, stop))
+                    .collect()
+            })
+            .collect();
         let entry_minutes: Vec<i64> = entry_minutes_by_day
             .iter()
             .flat_map(|entries| entries.iter().copied())
@@ -114,15 +120,16 @@ fn minutes_between(entries: &[Entry], start: OffsetDateTime, stop: OffsetDateTim
         .fold(0, |sum, entry| sum + entry.minutes_between(start, stop))
 }
 
-fn minutes_between_days(entries: &[Entry], start: Date, stop: Date) -> i64 {
+fn minutes_between_days<TS: TimeSource>(
+    entries: &[Entry],
+    start: Date,
+    stop: Date,
+    ts: &TS,
+) -> i64 {
     minutes_between(
         entries,
-        start
-            .midnight()
-            .assume_offset(DefaultTimeSource.local_offset()),
-        stop.next_day()
-            .midnight()
-            .assume_offset(DefaultTimeSource.local_offset()),
+        start.midnight().assume_offset(ts.local_offset()),
+        stop.next_day().midnight().assume_offset(ts.local_offset()),
     )
 }
 
@@ -137,6 +144,7 @@ fn sqrtint(n: i64) -> i64 {
 #[cfg(test)]
 mod tests {
     use crate::parser::parse_entries;
+    use crate::timesource::real_time::DefaultTimeSource;
     use time::date;
 
     type TestRes = Result<(), Box<dyn std::error::Error>>;
@@ -156,7 +164,7 @@ mod tests {
                      2013-09-05 11:39,2013-09-05 11:49\n";
         let entries = parse_entries(input.as_bytes())?;
         let sparks = vec![0, 1, 2, 3, 4, 5, 6];
-        let result = super::calc(entries, &sparks);
+        let result = super::calc(entries, &sparks, &DefaultTimeSource);
         assert_eq!(
             result,
             vec![

--- a/src/report/all.rs
+++ b/src/report/all.rs
@@ -1,5 +1,6 @@
-use crate::entry::{local_offset, Entry};
+use crate::entry::Entry;
 use crate::iter::{each_day_in_week, each_week};
+use crate::timesource::local_offset;
 use std::fmt::Debug;
 use time::{Date, Duration, OffsetDateTime};
 

--- a/src/report/days.rs
+++ b/src/report/days.rs
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_single_entry() -> TestRes {
         let input = "2013-09-04 11:04,2013-09-04 12:24\n";
-        let entries = parse_entries(input.as_bytes())?;
+        let entries = parse_entries(input.as_bytes(), &DefaultTimeSource)?;
         assert_eq!(
             prepare(entries, &DefaultTimeSource),
             Report {
@@ -187,7 +187,7 @@ mod tests {
     fn test_entry_covering_now() -> TestRes {
         set_mock_time(date!(2013 - 09 - 04), time!(12:00), offset!(-04:00));
         let input = "2013-09-04 11:04 -0400";
-        let entries = parse_entries(input.as_bytes())?;
+        let entries = parse_entries(input.as_bytes(), &DefaultTimeSource)?;
         assert_eq!(
             prepare(entries, &MockTimeSource),
             Report {
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn test_entry_spanning_weekend() -> TestRes {
         let input = "2013-11-16 00:00,2013-11-17 09:20";
-        let entries = parse_entries(input.as_bytes())?;
+        let entries = parse_entries(input.as_bytes(), &DefaultTimeSource)?;
         assert_eq!(
             prepare(entries, &DefaultTimeSource),
             Report {
@@ -247,7 +247,7 @@ mod tests {
                      2016-01-04 11:16,2016-01-04 11:26\n\
                      2016-01-05 11:26,2016-01-05 11:39\n\
                      2016-01-05 11:39,2016-01-05 11:49\n";
-        let entries = parse_entries(input.as_bytes())?;
+        let entries = parse_entries(input.as_bytes(), &DefaultTimeSource)?;
         assert_eq!(
             prepare(entries, &DefaultTimeSource),
             Report {

--- a/src/report/days.rs
+++ b/src/report/days.rs
@@ -1,5 +1,6 @@
-use crate::entry::{local_offset, Entry};
+use crate::entry::Entry;
 use crate::iter::{each_day_in_week, each_week};
+use crate::timesource::local_offset;
 use std::fmt::{self, Display, Formatter};
 use time::{Date, Duration};
 
@@ -137,9 +138,9 @@ fn finish(state: Option<State>) -> Report {
 #[cfg(test)]
 mod tests {
     use super::{prepare, Month, Report, Week, Year};
-    use crate::entry::mock_time::*;
     use crate::entry::Entry;
     use crate::parser::parse_entries;
+    use crate::timesource::mock_time::set_mock_time;
     use pretty_assertions::assert_eq;
     use time::{date, offset, time};
 

--- a/src/report/days.rs
+++ b/src/report/days.rs
@@ -145,7 +145,7 @@ mod tests {
     use super::{prepare, Month, Report, Week, Year};
     use crate::entry::Entry;
     use crate::parser::parse_entries;
-    use crate::timesource::mock_time::{set_mock_time, MockTimeSource};
+    use crate::timesource::mock_time::mock_time;
     use crate::timesource::real_time::DefaultTimeSource;
     use pretty_assertions::assert_eq;
     use time::{date, offset, time};
@@ -185,11 +185,11 @@ mod tests {
 
     #[test]
     fn test_entry_covering_now() -> TestRes {
-        set_mock_time(date!(2013 - 09 - 04), time!(12:00), offset!(-04:00));
+        let ts = mock_time(date!(2013 - 09 - 04), time!(12:00), offset!(-04:00));
         let input = "2013-09-04 11:04 -0400";
-        let entries = parse_entries(input.as_bytes(), &DefaultTimeSource)?;
+        let entries = parse_entries(input.as_bytes(), &ts)?;
         assert_eq!(
-            prepare(entries, &MockTimeSource),
+            prepare(entries, &ts),
             Report {
                 years: vec![Year {
                     year: 2013,

--- a/src/report/days.rs
+++ b/src/report/days.rs
@@ -1,5 +1,5 @@
 use crate::entry::Entry;
-use crate::iter::{each_day_in_week, each_week_ts};
+use crate::iter::{each_day_in_week, each_week};
 use crate::timesource::{real_time::DefaultTimeSource, TimeSource};
 use std::fmt::{self, Display, Formatter};
 use time::{Date, Duration};
@@ -39,7 +39,7 @@ pub fn prepare(entries: Vec<Entry>) -> Report {
 
 fn prepare_ts<TS: TimeSource>(entries: Vec<Entry>, ts: &TS) -> Report {
     let mut state = None;
-    for (week_start, entries) in each_week_ts(entries, ts) {
+    for (week_start, entries) in each_week(entries, ts) {
         state = Some(prepare_week(state, week_start, entries, ts));
     }
     finish(state)
@@ -114,7 +114,7 @@ fn prepare_week<TS: TimeSource>(
 
 fn convert_week<TS: TimeSource>(start: Date, entries: Vec<Entry>, ts: &TS) -> Week {
     let mut minutes = [0; 7];
-    for (day_start, entries) in each_day_in_week(entries, start) {
+    for (day_start, entries) in each_day_in_week(entries, start, ts) {
         let i = (day_start - start).whole_days();
         minutes[i as usize] = minutes_on_day(day_start, entries, ts);
     }

--- a/src/timesource.rs
+++ b/src/timesource.rs
@@ -6,6 +6,7 @@ pub mod real_time {
         static LOCAL_OFFSET: RefCell<Option<UtcOffset>> = RefCell::new(None);
     }
 
+    #[derive(Default)]
     pub struct DefaultTimeSource;
 
     impl super::TimeSource for DefaultTimeSource {
@@ -40,7 +41,10 @@ pub mod mock_time {
         static MOCK_TIME: RefCell<Option<OffsetDateTime>> = RefCell::new(None);
     }
 
-    pub struct MockTimeSource;
+    #[derive(Default)]
+    pub struct MockTimeSource /*{
+        pub time: OffsetDateTime,
+    }*/;
 
     impl super::TimeSource for MockTimeSource {
         fn now(&self) -> OffsetDateTime {
@@ -69,16 +73,3 @@ pub trait TimeSource {
     fn local_offset(&self) -> time::UtcOffset;
     fn now(&self) -> time::OffsetDateTime;
 }
-
-pub fn now() -> time::OffsetDateTime {
-    TS.now()
-}
-
-pub fn local_offset() -> time::UtcOffset {
-    TS.local_offset()
-}
-
-#[cfg(test)]
-static TS: mock_time::MockTimeSource = mock_time::MockTimeSource;
-#[cfg(not(test))]
-static TS: real_time::DefaultTimeSource = real_time::DefaultTimeSource;

--- a/src/timesource.rs
+++ b/src/timesource.rs
@@ -6,7 +6,7 @@ pub mod real_time {
         static LOCAL_OFFSET: RefCell<Option<UtcOffset>> = RefCell::new(None);
     }
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct DefaultTimeSource;
 
     impl super::TimeSource for DefaultTimeSource {
@@ -41,7 +41,7 @@ pub mod mock_time {
         static MOCK_TIME: RefCell<Option<OffsetDateTime>> = RefCell::new(None);
     }
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct MockTimeSource /*{
         pub time: OffsetDateTime,
     }*/;

--- a/src/timesource.rs
+++ b/src/timesource.rs
@@ -32,40 +32,27 @@ pub mod real_time {
 
 #[cfg(test)]
 pub mod mock_time {
-    // Adapted from https://blog.iany.me/2019/03/how-to-mock-time-in-rust-tests-and-cargo-gotchas-we-met/
-
-    use std::cell::RefCell;
     use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
-    thread_local! {
-        static MOCK_TIME: RefCell<Option<OffsetDateTime>> = RefCell::new(None);
+    #[derive(Clone)]
+    pub struct MockTimeSource {
+        dt: OffsetDateTime,
     }
-
-    #[derive(Default, Clone)]
-    pub struct MockTimeSource /*{
-        pub time: OffsetDateTime,
-    }*/;
 
     impl super::TimeSource for MockTimeSource {
         fn now(&self) -> OffsetDateTime {
-            //self.time.clone()
-            MOCK_TIME.with(|cell| {
-                cell.borrow()
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_else(OffsetDateTime::now_local)
-            })
+            self.dt.clone()
         }
 
         fn local_offset(&self) -> UtcOffset {
-            self.now().offset()
+            self.dt.offset()
         }
     }
 
-    pub fn set_mock_time(date: Date, time: Time, offset: UtcOffset) {
-        MOCK_TIME.with(|cell| {
-            *cell.borrow_mut() = Some(PrimitiveDateTime::new(date, time).assume_offset(offset))
-        });
+    pub fn mock_time(date: Date, time: Time, offset: UtcOffset) -> MockTimeSource {
+        MockTimeSource {
+            dt: PrimitiveDateTime::new(date, time).assume_offset(offset),
+        }
     }
 }
 

--- a/src/timesource.rs
+++ b/src/timesource.rs
@@ -26,7 +26,7 @@ pub mod mock_time {
 
     impl super::TimeSource for MockTimeSource {
         fn now(&self) -> OffsetDateTime {
-            self.dt.clone()
+            self.dt
         }
 
         fn local_offset(&self) -> UtcOffset {

--- a/src/timesource.rs
+++ b/src/timesource.rs
@@ -1,12 +1,7 @@
 pub mod real_time {
-    use std::cell::RefCell;
     use time::{OffsetDateTime, UtcOffset};
 
-    thread_local! {
-        static LOCAL_OFFSET: RefCell<Option<UtcOffset>> = RefCell::new(None);
-    }
-
-    #[derive(Default, Clone)]
+    #[derive(Clone)]
     pub struct DefaultTimeSource;
 
     impl super::TimeSource for DefaultTimeSource {
@@ -15,17 +10,7 @@ pub mod real_time {
         }
 
         fn local_offset(&self) -> UtcOffset {
-            LOCAL_OFFSET.with(|cell| {
-                let val = cell.borrow().as_ref().cloned();
-                match val {
-                    Some(ret) => ret,
-                    None => {
-                        let ret = UtcOffset::current_local_offset();
-                        *cell.borrow_mut() = Some(ret);
-                        ret
-                    }
-                }
-            })
+            UtcOffset::current_local_offset()
         }
     }
 }

--- a/src/timesource.rs
+++ b/src/timesource.rs
@@ -1,0 +1,64 @@
+#[cfg(not(test))]
+pub mod real_time {
+    use std::cell::RefCell;
+    use time::{OffsetDateTime, UtcOffset};
+
+    thread_local! {
+        static LOCAL_OFFSET: RefCell<Option<UtcOffset>> = RefCell::new(None);
+    }
+
+    pub fn now() -> OffsetDateTime {
+        OffsetDateTime::now_local()
+    }
+
+    pub fn local_offset() -> UtcOffset {
+        LOCAL_OFFSET.with(|cell| {
+            let val = cell.borrow().as_ref().cloned();
+            match val {
+                Some(ret) => ret,
+                None => {
+                    let ret = UtcOffset::current_local_offset();
+                    *cell.borrow_mut() = Some(ret);
+                    ret
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+pub mod mock_time {
+    // Adapted from https://blog.iany.me/2019/03/how-to-mock-time-in-rust-tests-and-cargo-gotchas-we-met/
+
+    use std::cell::RefCell;
+    use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+    thread_local! {
+        static MOCK_TIME: RefCell<Option<OffsetDateTime>> = RefCell::new(None);
+    }
+
+    pub fn now() -> OffsetDateTime {
+        //self.time.clone()
+        MOCK_TIME.with(|cell| {
+            cell.borrow()
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(OffsetDateTime::now_local)
+        })
+    }
+
+    pub fn local_offset() -> UtcOffset {
+        now().offset()
+    }
+
+    pub fn set_mock_time(date: Date, time: Time, offset: UtcOffset) {
+        MOCK_TIME.with(|cell| {
+            *cell.borrow_mut() = Some(PrimitiveDateTime::new(date, time).assume_offset(offset))
+        });
+    }
+}
+
+#[cfg(test)]
+pub use mock_time::{local_offset, now};
+#[cfg(not(test))]
+pub use real_time::{local_offset, now};


### PR DESCRIPTION
This branch eliminates some global variables that I'd added to support mocking the current time.
